### PR TITLE
A couple of small fixes

### DIFF
--- a/src/atompackagesarchive.js
+++ b/src/atompackagesarchive.js
@@ -58,6 +58,7 @@ function paginatedRequests(backup) {
     if (paginatedObj.page == paginatedObj.totalPages) {
       console.log('Reached last page. Calling Package Write');
       if (backup == "PACKAGES" || backup == "ALL") {
+        fs.mkdirSync('./archive/packages/', { recursive: true })
         fs.writeFileSync('./archive/packages/all_packages.json', JSON.stringify(packages, '  ', '  '));
         console.log('Wrote full packages.');
       }
@@ -78,6 +79,7 @@ async function getIndividualPage(page, backup, failed, maxRetry) {
         var pageContent = response.data;
 
         // now to write the content
+        fs.mkdirSync('./archive/paginated/', { recursive: true })
         fs.writeFileSync(`./archive/paginated/page_${page}_content.json`,
           JSON.stringify(pageContent, '  ', '  '));
         fs.writeFileSync(`./archive/paginated/page_${page}_headers.txt`,
@@ -86,6 +88,7 @@ async function getIndividualPage(page, backup, failed, maxRetry) {
         console.log(`Wrote Headers & Content for Page: ${page}`);
 
         if (backup == "PACKAGES" || backup == "ALL") {
+          fs.mkdirSync('./archive/packages/', { recursive: true })
           fs.writeFileSync('./archive/packages/all_packages.json', JSON.stringify(packages, '  ', '  '));
           console.log('Wrote full packages.');
         }

--- a/src/options.js
+++ b/src/options.js
@@ -8,7 +8,7 @@ function parseArgv(rawArg) {
 
   if (rawArg.length < 1) {
     console.log('No Arguments passed. Defaulting to ALL');
-    returnObj.backup == "ALL";
+    returnObj.backup = "ALL";
     return returnObj;
   } else {
 


### PR DESCRIPTION
Changes:
- Assignment instead of comparison for 'backup' var in src/options.js.
  - Tiny fix so that the "`ALL`" `--backup` option is passed to the main script if the user doesn't specify a `--backup` option
- Makes sure folders are created before writing the output files in them. (For src/atompackagesarchive.js).
  -  Prevents `Error: ENOENT: no such file or directory, open './archive/packages/all_packages.json'`
---

Thanks for making this tool! Works for me with these changes.